### PR TITLE
fix: make nav always on top of page

### DIFF
--- a/src/app/styles/globals.css
+++ b/src/app/styles/globals.css
@@ -76,6 +76,11 @@
      max-width: 100vw;
    }
 
+   /* Offset for fixed navbar */
+   body {
+     padding-top: var(--header-height, 60px); /* Account for fixed navbar height */
+   }
+
    /* Prevent code blocks from causing horizontal scroll */
    pre, code, .code-block-wrapper {
      max-width: 100%;

--- a/src/components/Nav/Nav.module.css
+++ b/src/components/Nav/Nav.module.css
@@ -5,7 +5,7 @@
 /* ======================================== */
 
 .navContainer {
-    position: sticky;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;
@@ -27,7 +27,7 @@
         rgba(var(--accent-cool-rgb), 0.1) 100%
     );
     box-shadow: 0 4px 15px -2px rgba(var(--accent-vibrant-rgb), 0.15), 0 8px 30px -10px var(--nav-shadow-dark, rgba(var(--shadow-color-rgb), 0.5));
-    z-index: 1000; /* Increased z-index for proper stickiness */
+    z-index: 10002; /* Highest z-index to ensure navbar stays on top */
 }
 
 .navScrolled {


### PR DESCRIPTION
## Summary by Sourcery

Ensure the navigation bar remains fixed at the top by setting its position to fixed with a higher z-index and adjusting body padding to offset its height.

Bug Fixes:
- Change navbar position to fixed and bump its z-index to keep it layered above all content
- Add top padding to the body to account for the fixed navbar height and prevent content overlap